### PR TITLE
Symbolic sums

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,91 @@
 # Egyptian Fractions
 
-with small denominators
+* small denominators: largest denominator factor not greater than original denominator
+* suitable for large inputs
 
-* largest denominator factor not greater than original denominator
-* compare to Wolfram Alpha: https://www.wolframalpha.com/input?i=egyptian+fraction+2023%2F2024
-
-compare e.g.:
+## Usage:
 
 ```
-7/19 == 1/3 + 1/29 + 1/1653   (wolfram alpha)
-7/19 == 1/3 + 1/33 + 1/209    (this algorithm)
+Egyptian Fractions
+
+Usage: egypt [OPTIONS] [NUMERATOR] [DENOMINATOR]
+
+Arguments:
+  [NUMERATOR]    [default: 1]
+  [DENOMINATOR]  [default: 1]
+
+Options:
+  -r, --reverse        Reverse merge strategy
+  -m, --merge          Extra merge step with quadratic complexity possibly reducing number of terms
+      --raw            Output minimal number of raw quadruplets (aka symbolic sums)
+  -s, --silent         No output
+      --batch          Batch mode (expects numerator and denominator on each line of standard input)
+  -l, --limit <LIMIT>  Maximum number of terms for breaking large symbolic sums [default: 2]
+  -h, --help           Print help
+  -V, --version        Print version
+```
+
+
+```
+$ time ./egypt -s 162259276829213363391578010288127 170141183460469231731687303715884105727
+
+real    0m0.003s
+user    0m0.002s
+sys     0m0.001s
 ```
 
 ```
-2023/2024 == 1/2 + 1/3 + 1/7 + 1/43 + 1/16768 + 1/766160103 + 1/978335504948790912   (wolfram alpha)
-2023/2024 == 1/2 + 1/3 + 1/8 + 1/33 + 1/92                                           (this algorithm)
-2023/2024 == 1/2 + 1/3 + 1/7 + 1/43 + 1/18447 + 1/184184                             (this algorithm --reverse)
+$ time ./egypt 999999 1000000``
+1       2
+1       4
+1       8
+1       16
+1       33
+1       50
+1       83
+1       12450
+1       32912
+1       49368
+1       90387
+1       285716
+1       571432
+1       1999996
+1       685610442
+1       2057423870
+1       11904714285
+1       83332333335
+1       499999000000
+
+real    0m0.002s
+user    0m0.001s
+sys     0m0.000s
 ```
 
-* based on Lissajous Curves: https://mathworld.wolfram.com/LissajousCurve.html
+---
+
+## Samples
+### 7 / 19
+
+* Wolfram|Alpha
+  * 1 / 3 + 1 / 29 + 1 / 1653   
+* `egypt --merge --limit 19 7 19`
+  * 1 / 3 + 1 / 33 + 1 / 209    
+
+### 2023 / 2024
+* Wolfram|Alpha
+  * 1 / 2 + 1 / 3 + 1 / 7 + 1 / 43 + 1 / 16768 + 1 / 766160103 + 1 / 978335504948790912
+* `egypt --merge --limit 2023 2023 2024`
+  * 1 / 2 + 1 / 3 + 1 / 8 + 1 / 33 + 1 / 92
+* `egypt --reverse --merge --limit 2023 2023 2024`
+  * 1 / 2 + 1 / 3 + 1 / 7 + 1 / 43 + 1 / 18447 + 1 / 184184
+* `egypt 2023 2024`
+    *   1 / 2 + 1 / 4 + 1 / 8 + 1 / 11 + 1 / 33 + 1 / 674 + 1 / 899 + 1 / 2442 + 1 / 4044 + 1 / 24938 + 1 / 2046264 + 1 / 2423704
+
+---
+
+## Illustrations
+
+* Lissajous Curves: https://mathworld.wolfram.com/LissajousCurve.html
 
 ![lissajous1](doc/7_11.png)
 
@@ -30,8 +97,8 @@ compare e.g.:
 
 by different rational numbers with denominator coprime to the original denominator
 
-### 7/11
+### 7 / 11
 ![approx_7_11](doc/approx_7_11.png)
 
-### 7/11 errors
+### 7 / 11 errors
 ![approx_7_11_err](doc/approx_7_11_err.png)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # Egyptian Fractions
 
-* small denominators: largest denominator factor not greater than original denominator
-* suitable for large inputs
+Fast algorithm for representing rational numbers as egyptian fractions.
 
-## Usage:
+## Properties
+* suitable for very large inputs
+* returns rather small denominators
+
+## Usage
 
 ```
 Egyptian Fractions
@@ -25,7 +28,7 @@ Options:
   -V, --version        Print version
 ```
 
-
+## Performance
 ```
 $ time ./egypt -s 162259276829213363391578010288127 170141183460469231731687303715884105727
 
@@ -63,7 +66,8 @@ sys     0m0.000s
 
 ---
 
-## Samples
+## Examples
+
 ### 7 / 19
 
 * Wolfram|Alpha
@@ -80,6 +84,15 @@ sys     0m0.000s
   * 1 / 2 + 1 / 3 + 1 / 7 + 1 / 43 + 1 / 18447 + 1 / 184184
 * `egypt 2023 2024`
     *   1 / 2 + 1 / 4 + 1 / 8 + 1 / 11 + 1 / 33 + 1 / 674 + 1 / 899 + 1 / 2442 + 1 / 4044 + 1 / 24938 + 1 / 2046264 + 1 / 2423704
+
+## Note
+
+> * returns rather small denominators
+>
+When using legacy configuration `egypt --merge --limit <LIMIT> <NUMERATOR> <DENOMINATOR>`, where `LIMIT >= DENOMINATOR - 1`,
+largest denominator factor should not be greater than original denominator. Fast default limit is however `2`,
+which means that *bisecting* large symbolic sums can introduce bigger denominators. Moreover, `--limit` argument is itself
+limited by `usize`, as opposed to other `BigInt` inputs.
 
 ---
 

--- a/doc/egyptian_fractions_rc.wls
+++ b/doc/egyptian_fractions_rc.wls
@@ -1,0 +1,48 @@
+#!/usr/bin/env wolframscript
+(* ::Package:: *)
+
+(* ::Input:: *)
+(*p[{u_,v_,i_,j_},lim_]:=If[j-i+1>lim,Module[{ret={},a,b},*)
+(*{a,b}=NumeratorDenominator@First@t@{{u,v,i,j}};*)
+(*If[OddQ@a,AppendTo[ret,Floor[a/2]/b];AppendTo[ret,Ceiling[a/2]/b],*)
+(*AppendTo[ret,(a/2-1)/b];AppendTo[ret,(a/2+1)/b]];Flatten[f/@DeleteCases[ret,0],1]*)
+(*],{{u,v,i,j}}]*)
+(*f[q_Rational]:=Module[{e={},x,v,a,b,t,r=q},*)
+(*While[{a,b}=NumeratorDenominator@r;r>0&&b>1,*)
+(*v=b-Denominator[1/# Floor[a/b #]&@If[b-a==1,a,Mod[ExtendedGCD[a,b][[2,1]]+b,b]]];*)
+(*t=Floor[a b / (1+a v)];*)
+(*PrependTo[e,{b-t v,v,1,t}];r-=t/(b(b-t v))];*)
+(*If[r>0,Prepend[e,{r,0,1,1}],e]](*raw quadruplets*)*)
+(*f0[q_List]:=If[#3==#4,1/#1/(#1-#2),HoldForm[Sum[#1,{k,#2,#3}]]&@@{1/(#1-#2 k)/(#1-#2(k-1)),#3,#4}]&@@@q(*symbolic sums of egyptian terms*)*)
+(*v[q_List]:=If[#3==#4,1/(#1+#2 #3)/(#1+#2(#3-1)),HoldForm@Sum[#1,{k,#2,#3}]&@@{1/((#1+k #2)(#1 +(k-1)#2)),#3,#4}]&@@@q(*symbolic sums of egyptian terms*)*)
+(*e[q_List]:=ReverseSort@Flatten[Table[1/(#1+#2 k)/(#1+#2(k-1)),{k,#3,#4}]&@@@q] (*evaluate all egyptian terms - worst case slow*)*)
+(*h[q_List]:=HoldForm/@Table[1/(#1+#2(HoldForm[#]&@k))/(#1+#2(HoldForm@#&@(k-1))),{k,#3,#4}]&@@@q //Total/@#&(*evaluate all egyptian terms - worst case slow*)*)
+(*t[x_List]:=(1-#3+#4)/((#1-#2+#2 #3) (#1+#2 #4))&@@@x (*evaluate symbolic sums totals*)*)
+(*m[eg_]:=Module[{i,j,ret={}},*)
+(*	For[i=1,i<=Length@eg,If[Denominator@eg[[i]]>1,*)
+(*		j=Select[Flatten@Position[Numerator[Accumulate@eg[[i;;]]],1],Position[eg,Total@eg[[i;;i+#-1]]]=={}&&Position[ret,Total@eg[[i;;i+#-1]]]=={}&];*)
+(*		j=If[j!={},i+Last@j-1,i];*)
+(*		AppendTo[ret,Total@eg[[i;;j]] ];i=j+1,*)
+(*		AppendTo[ret,eg[[i]]];i+=1]*)
+(*];*)
+(*ReverseSort@ret*)
+(*]*)
+(*split[eg_List,lim_]:=FixedPoint[Join@@(p[#,lim]&/@#)&,eg]*)
+(*correct[eg_List]:=Module[{x=Split@eg,i},*)
+(*i=FirstPosition[x,_List?(Length@#>1&)];*)
+(*ReverseSort@Flatten@If[i=={},x,i=First@i;*)
+(*Join[x[[;;i-1]],{e@f@Total@x[[i]]},x[[i+1;;]]]*)
+(*]]*)
+(*F[q_Rational]:=correct@e@split[f@q,8]*)
+
+
+(* ::Input:: *)
+(*mr[exp_]:=Divide@@(Power[2,MersennePrimeExponent@{exp,exp+1}]-1)*)
+
+
+(* ::Input:: *)
+(*Timing[Total@F@#-#]&@mr@9*)
+
+
+(* ::Input:: *)
+(*Timing@{F@(7/11),m@F@(7/11)}*)

--- a/wl/Egypt.wl
+++ b/wl/Egypt.wl
@@ -106,7 +106,7 @@ FixDuplicates[eg_List] :=
             i = FirstPosition[x, _List ? (Length @ # > 1&)];
             ReverseSort @
                 Flatten @
-                    If[i == {},
+                    If[MissingQ @ i || i == {},
                         x
                         ,
                         i = First @ i;

--- a/wl/Egypt.wl
+++ b/wl/Egypt.wl
@@ -132,7 +132,7 @@ EgyptianFractions[q_Rational, OptionsPattern[]] :=
                 FormatRawFractions @ raw
             ,
             "Merged",
-                FixDuplicates @ MergeFractions @ FixDuplicates @ EvaluateRawFractions
+                FixDuplicates @ MergeFractions @ EvaluateRawFractions
                      @ HalveAll[raw, OptionValue[MaxItems]]
         ]
     ]
@@ -150,7 +150,7 @@ sqrth[x_, n_] :=
     1 + Sum[HoldForm[#]& @ term[x, j], {j, 1, n}]
 
 sqrtl[x_, n_] :=
-    [{1}, Table[term[x, j], {j, 1, n}]]
+    Join[{1}, Table[term[x, j], {j, 1, n}]]
 
 pellsol[n_, c_] :=
     Normal @ First @ Solve[x^2 - n y^2 == 1, {x, y}, PositiveIntegers

--- a/wl/Egypt.wl
+++ b/wl/Egypt.wl
@@ -4,6 +4,8 @@ BeginPackage["Egypt`"]
 
 EgyptianFractions::usage = "EgyptianFractions[ q] converts a rational number to an egyptian fractions representation"
 
+EgyptianSqrtApproximate::usage = "EgyptianSqrtApproximate[ n] approximates a square root by a rational number using egyptian fractions"
+
 k;
 
 Begin["Private`"]
@@ -137,9 +139,40 @@ EgyptianFractions[q_Rational, OptionsPattern[]] :=
 
 Options[EgyptianFractions] = {Method -> "Classical", MaxItems -> 8}
 
+term[x_, j_] :=
+    1 / (1 + Sum[2 ^ (i - 1) x^i Factorial[j + i] / Factorial[j - i] 
+        / Factorial[2 i], {i, 1, j}])
+
+sqrtt[x_, n_] :=
+    1 + Sum[term[x, j], {j, 1, n}]
+
+sqrth[x_, n_] :=
+    1 + Sum[HoldForm[#]& @ term[x, j], {j, 1, n}]
+
+sqrtl[x_, n_] :=
+    [{1}, Table[term[x, j], {j, 1, n}]]
+
+pellsol[n_, c_] :=
+    Normal @ First @ Solve[x^2 - n y^2 == 1, {x, y}, PositiveIntegers
+        ] /. C[1] -> c
+
+EgyptianSqrtApproximate[n_, OptionsPattern[]] :=
+    Module[{sol, acc = OptionValue[Accuracy]},
+        sol = pellsol[n, 1];
+        Switch[OptionValue[Method],
+            "List",
+                {(x - 1) / y, sqrtl[x - 1, acc]} /. sol
+            ,
+            "Rational",
+                (x - 1) / y sqrtt[x - 1, acc] /. sol
+            ,
+            "Expression",
+                (x - 1) / y sqrth[x - 1, acc] /. sol
+        ]
+    ]
+
+Options[EgyptianSqrtApproximate] = {Method -> "List", Accuracy -> 8}
+
 End[]
 
 EndPackage[]
-
-
-

--- a/wl/Egypt.wl
+++ b/wl/Egypt.wl
@@ -131,13 +131,17 @@ EgyptianFractions[q_Rational, OptionsPattern[]] :=
             "Expression",
                 FormatRawFractions @ raw
             ,
-            "Merged",
+            "Merge",
+                FixDuplicates @ MergeFractions @ Reverse @ EvaluateRawFractions
+                     @ HalveAll[raw, OptionValue[MaxItems]]
+            ,
+            "ReverseMerge",
                 FixDuplicates @ MergeFractions @ EvaluateRawFractions
                      @ HalveAll[raw, OptionValue[MaxItems]]
         ]
     ]
 
-Options[EgyptianFractions] = {Method -> "Classical", MaxItems -> 8}
+Options[EgyptianFractions] = {Method -> "Classical", MaxItems -> 2}
 
 term[x_, j_] :=
     1 / (1 + Sum[2 ^ (i - 1) x^i Factorial[j + i] / Factorial[j - i] 

--- a/wl/Egypt.wl
+++ b/wl/Egypt.wl
@@ -1,0 +1,145 @@
+(* ::Package:: *)
+
+BeginPackage["Egypt`"]
+
+EgyptianFractions::usage = "EgyptianFractions[ q] converts a rational number to an egyptian fractions representation"
+
+k;
+
+Begin["Private`"]
+
+HalveRawFractionsOnce[{u_, v_, i_, j_}, lim_] :=
+    If[j - i + 1 > lim,
+        Module[{ret = {}, a, b},
+            {a, b} = NumeratorDenominator @ First @ CalculateRawFractions
+                 @ {{u, v, i, j}};
+            If[OddQ @ a,
+                AppendTo[ret, Floor[a / 2] / b];
+                AppendTo[ret, Ceiling[a / 2] / b]
+                ,
+                AppendTo[ret, (a / 2 - 1) / b];
+                AppendTo[ret, (a / 2 + 1) / b]
+            ];
+            Flatten[RawFractions /@ DeleteCases[ret, 0], 1]
+        ]
+        ,
+        {{u, v, i, j}}
+    ]
+
+RawFractions[q_Rational] :=
+    Module[{e = {}, x, v, a, b, t, r = q},
+        While[
+            {a, b} = NumeratorDenominator @ r;
+            r > 0 && b > 1
+            ,
+            v =
+                b -
+                    Denominator[
+                        1 / # Floor[a / b #]& @
+                            If[b - a == 1,
+                                a
+                                ,
+                                Mod[ExtendedGCD[a, b][[2, 1]] + b, b]
+                                    
+                            ]
+                    ];
+            t = Floor[a b / (1 + a v)];
+            PrependTo[e, {b - t v, v, 1, t}];
+            r -= t / b / (b - t v)
+        ];
+        If[r > 0,
+            Prepend[e, {1 / Sqrt @ r, 0, 0, 0}]
+            ,
+            e
+        ]
+    ]
+
+FormatRawFractions[q_List] :=
+    If[#3 == #4,
+            1 / (#1 + #2 #3) / (#1 + #2 (#3 - 1))
+            ,
+            HoldForm @ Sum[#1, {k, #2, #3}]& @@ {1 / (#1 + k #2) / (#1
+                 + (k - 1) #2), #3, #4}
+        ]& @@@ q
+
+EvaluateRawFractions[q_List] :=
+    ReverseSort @ Flatten[Table[1 / (#1 + #2 k) / (#1 + #2 (k - 1)), 
+        {k, #3, #4}]& @@@ q]
+
+CalculateRawFractions[x_List] :=
+    (1 - #3 + #4) / (#1 - #2 + #2 #3) / (#1 + #2 #4)& @@@ x
+
+MergeFractions[eg_List] :=
+    Module[{i, j, ret = {}},
+        For[
+            i = 1
+            ,
+            i <= Length @ eg
+            ,
+            If[Denominator @ eg[[i]] > 1,
+                j = Flatten @ Position[Numerator[Accumulate @ eg[[i ;;
+                     ]]], 1];
+                j =
+                    If[j != {},
+                        i + Last @ j - 1
+                        ,
+                        i
+                    ];
+                AppendTo[ret, Total @ eg[[i ;; j]]];
+                i = j + 1
+                ,
+                AppendTo[ret, eg[[i]]];
+                i += 1
+            ]
+        ];
+        ReverseSort @ ret
+    ]
+
+HalveAll[eg_List, lim_] :=
+    FixedPoint[Join @@ (HalveRawFractionsOnce[#, lim]& /@ #)&, eg]
+
+FixDuplicates[eg_List] :=
+    FixedPoint[
+        Module[{x = Split @ ReverseSort @ #, i},
+            i = FirstPosition[x, _List ? (Length @ # > 1&)];
+            ReverseSort @
+                Flatten @
+                    If[i == {},
+                        x
+                        ,
+                        i = First @ i;
+                        Join[x[[ ;; i - 1]], {EvaluateRawFractions @ 
+                            RawFractions @ Total @ x[[i]]}, x[[i + 1 ;; ]]]
+                    ]
+        ]&
+        ,
+        eg
+    ]
+
+EgyptianFractions[q_Rational, OptionsPattern[]] :=
+    Module[{raw = RawFractions @ q},
+        Switch[OptionValue[Method],
+            "Classical",
+                FixDuplicates @ EvaluateRawFractions @ HalveAll[raw, 
+                    OptionValue[MaxItems]]
+            ,
+            "Raw",
+                raw
+            ,
+            "Expression",
+                FormatRawFractions @ raw
+            ,
+            "Merged",
+                FixDuplicates @ MergeFractions @ FixDuplicates @ EvaluateRawFractions
+                     @ HalveAll[raw, OptionValue[MaxItems]]
+        ]
+    ]
+
+Options[EgyptianFractions] = {Method -> "Classical", MaxItems -> 8}
+
+End[]
+
+EndPackage[]
+
+
+


### PR DESCRIPTION
* resolves #1
* usually gives more terms with default arguments
* original output can be mimicked using `--merge` switch and setting `--limit <den>` to the value of original denominator
* `--raw` switch semantics changed: outputs symbolic sums' quadruplets $(u, v, i, j)$
$$\sum_{k=i}^{j} \frac{1}{(u + k v) (u + (k - 1) v)}$$
* integer part of the input is internally raw encoded as $(n, 0, 0, 0)$ instead of the correct $(\frac{1}{\sqrt{n}}, 0,0,0)$
* includes a simple Wolfram Language package `wl/Egypt.wl`