### PR TITLE
Some optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ default-features = false
 features = ["integer", "rational", "std"]
 
 [profile.release]
-panic = "abort"
 opt-level = 3
+codegen-units = 1
+panic = "abort"
 debug = false

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Options:
 ```
 $ time ./egypt -s '2 9689 ^ 1 -' '2 9941 ^ 1 -'
 
-real    0m0.566s
-user    0m0.528s
-sys     0m0.036s
+real    0m0.345s
+user    0m0.296s
+sys     0m0.047s
 ```
 
 ```
@@ -102,6 +102,17 @@ When using legacy configuration `egypt --merge --limit <LIMIT> <NUMERATOR> <DENO
 largest denominator factor should not be greater than original denominator. Fast default limit is however `2`,
 which means that *bisecting* large symbolic sums can introduce bigger denominators. Moreover, `--limit` argument is itself
 limited by `usize`, as opposed to other `BigInt` inputs.
+
+## Relation to Continued Fractions
+
+```
+<< "wl/Egypt.wl"
+
+compare[Rational[p_, q_]] := {
+  Total /@ Partition[ Differences @ Convergents[ p/q ], 2],
+  ReleaseHold @ EgyptianFractions[ p/q , Method -> "Expression"]
+}
+```
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ fn fix_duplicates(eg: &Vec<(Integer, Integer, Integer, Integer)>)
     let mut last_i = 0;
     let mut eg = eg.clone();
     while last_i < eg.len() {
-        eg.sort_by(|x, y| { x.1.cmp(&y.1)});
+        eg.sort_by(|x, y| { y.1.cmp(&x.1)});
         let mut ret = vec![];
         let mut cnt = 1;
         let mut prev = eg.first().unwrap();
@@ -179,6 +179,7 @@ fn fix_duplicates(eg: &Vec<(Integer, Integer, Integer, Integer)>)
         eg.clear();
         eg.extend(ret);
     }
+    eg.sort_by(|x, y| { x.1.cmp(&y.1)});
     eg
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,8 @@ fn merge(eg: &Vec<(Integer, Integer, Integer, Integer)>) -> Vec<(Integer, Intege
 
 fn as_egyptian_fraction_symbolic(x0: &Integer, y0: &Integer, _expand: bool, ret: &mut Vec<(Integer, Integer, Integer, Integer)>) {
     let gcd = x0.clone().gcd(&y0);
-    let mut x = x0.div(&gcd).complete();
-    let mut y = y0.div(&gcd).complete();
+    let mut x = x0.clone().div(&gcd);
+    let mut y = y0.clone().div(&gcd);
     if x.ge(&y) {
         ret.push((x.clone().div(&y),0.into(), 0.into(), 0.into()));
         x.sub_assign(x.clone().div(&y).mul(&y));
@@ -96,13 +96,16 @@ fn expand(eg: &Vec<(Integer, Integer, Integer, Integer)>) -> Vec<(Integer, Integ
     for (b,v,i,j) in eg.iter() {
         if v.is_zero() && i.is_zero() && j.is_zero() {
             ret.push((b.clone(), Integer::from(1), Integer::from(0), Integer::from(0)));
-            continue;
-        }
-        for k in i.to_usize().unwrap() .. j.to_usize().unwrap() + 1 {
-            let num = Integer::from(1);
-            let den = b.sub(v).complete().add(v.clone().mul(&k))
-                .mul(b.add(v.clone().mul(k.clone())));
-            ret.push((num, den, Integer::from(0), Integer::from(0)));
+        } else {
+            for k in i.to_usize().unwrap()..j.to_usize().unwrap() + 1 {
+                ret.push((
+                    Integer::from(1),
+                    b.clone().sub(v).add(v.clone().mul(&k))
+                        .mul(b.add(v.clone().mul(k.clone()))),
+                    Integer::from(0),
+                    Integer::from(0)
+                ));
+            }
         }
     }
     ret

--- a/wl/Egypt.wl
+++ b/wl/Egypt.wl
@@ -32,13 +32,7 @@ RawFractions[q_Rational] :=
         While[
             a > 0 && b > 1
             ,
-            v =
-                b - Denominator[1 / # Quotient[a #, b]]& @
-                    If[b - a == 1,
-                        a
-                        ,
-                        Mod[ExtendedGCD[a, b][[2, 1]] + b, b]
-                    ];
+            v = Mod[-ExtendedGCD[a, b][[2, 1]], b];
             t = Quotient[a b, 1 + a v];
             vm = b - t v;
             PrependTo[e, {vm, v, 1, t}];
@@ -125,8 +119,14 @@ EgyptianFractions[q_Rational, OptionsPattern[]] :=
             "Raw",
                 raw
             ,
+            "SplitRaw",
+                HalveAll[raw, OptionValue[MaxItems]]
+            ,
             "Expression",
                 FormatRawFractions @ raw
+            ,
+            "SplitExpression",
+                FormatRawFractions @ HalveAll[raw, OptionValue[MaxItems]]
             ,
             "Merge",
                 FixDuplicates @ MergeFractions @ Reverse @ EvaluateRawFractions

--- a/wl/check.wls
+++ b/wl/check.wls
@@ -5,6 +5,5 @@ If[Not@AllTrue[Rest[First/@ fractions], # == 1 &], Print["bad num"]; Exit[1]];
 If[Not@DuplicateFreeQ[Last /@ fractions], Print["dupes"]; Exit[2]];
 original = Divide @@ (ToExpression /@ $ScriptCommandLine[[{2,3}]]);
 recovered = Divide @@@ fractions // Total;
-Print[Last@fractions];
 If[recovered != original, Print[{recovered - original,"wrong"}]; Exit[3] ];
 Exit[0];

--- a/wl/check.wls
+++ b/wl/check.wls
@@ -1,0 +1,10 @@
+#!/usr/bin/env wolframscript
+
+fractions = ReadList[$ScriptCommandLine[[4]], {Number,Number}];
+If[Not@AllTrue[Rest[First/@ fractions], # == 1 &], Print["bad num"]; Exit[1]];
+If[Not@DuplicateFreeQ[Last /@ fractions], Print["dupes"]; Exit[2]];
+original = Divide @@ (ToExpression /@ $ScriptCommandLine[[{2,3}]]);
+recovered = Divide @@@ fractions // Total;
+Print[Last@fractions];
+If[recovered != original, Print[{recovered - original,"wrong"}]; Exit[3] ];
+Exit[0];

--- a/wl/check.wls
+++ b/wl/check.wls
@@ -1,5 +1,5 @@
 #!/usr/bin/env wolframscript
-
+If[Length[$ScriptCommandLine]<4,Print["Usage: wl/check.wls <numerator> <denominator> <file>"]; Exit[0]]
 fractions = ReadList[$ScriptCommandLine[[4]], {Number,Number}];
 If[Not@AllTrue[Rest[First/@ fractions], # == 1 &], Print["bad num"]; Exit[1]];
 If[Not@DuplicateFreeQ[Last /@ fractions], Print["dupes"]; Exit[2]];

--- a/wl/test.wls
+++ b/wl/test.wls
@@ -1,0 +1,20 @@
+#!/usr/bin/env wolframscript
+If[Length[$ScriptCommandLine] < 3, Print["Usage: wl/test.wls <num_tests> <max_bits>"]; Exit[0]];
+testnum=ToExpression[$ScriptCommandLine[[2]]];
+testmag=ToExpression[$ScriptCommandLine[[3]]];
+file=CreateFile[];
+For[i=1,i<=testnum,
+  original=Divide@@RandomInteger[{1,2^testmag},2];
+  WriteString["stdout", StringJoin[{"\rTesting ", ToString@i}]];(*, ": ", Sequence@@ToString@NumeratorDenominator@original}]]*);
+  output = RunProcess[Join[{"target/release/egypt"}, NumeratorDenominator@original], "StandardOutput"];
+  fractions = ReadList[StringToStream@output, {Number, Number}];
+  error = If[Not@AllTrue[Rest[First/@ fractions], # == 1 &], Print[{original, "bad num\n"}]; True, False];
+  error = error || If[Not@DuplicateFreeQ[Last /@ fractions], Print[{original, Commonest[Last/@fractions], "dupes\n"}]; True, False];
+  recovered = Divide @@@ fractions // Total;
+  error = error || If[recovered != original, Print[{original, "wrong\n"}]; True, False];
+  If[error, Exit[1]];
+  i+=1;
+]
+Print["\nDone."]
+DeleteFile[file]
+


### PR DESCRIPTION
- [x] rust: get rid of rationals in core symbolic calculation
- [x] rust: avoid some unnecessary cloning
- [x] wolfram module: optimize core xgcd calculation
- [x] wolfram module: add methods (expression and raw for splitted output)
- [x] readme: point out relation to continued fractions
- [x] readme: update example execution time
- [x] ~~thoroughly~~ tested